### PR TITLE
Drop support of Python 2 and move to Sphinx 2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /nbproject/private/
+.vscode/
+venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+    - "3.6"
+    - "3.7"
+
+install:
+    - pip install -r requirements.txt
+
+script:
+    - make html

--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,16 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         = a4
-BUILDDIR      = _build
-LANG          = fr
+SPHINXOPTS       =
+SPHINXBUILD      = sphinx-build
+SPHINX_AUTOBUILD = sphinx-autobuild
+BUILDDIR         = _build
+LANG             = fr
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) tmp/$(LANG)
-# the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) tmp/$(LANG)
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean html singlehtml linkcheck
 
 # Taken from zf-framework documentation
 pre-build:
@@ -42,24 +38,8 @@ endif
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
-	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
-	@echo "  pickle     to make pickle files"
-	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
-	@echo "  qthelp     to make HTML files and a qthelp project"
-	@echo "  devhelp    to make HTML files and a Devhelp project"
-	@echo "  epub       to make an epub"
-	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  text       to make text files"
-	@echo "  man        to make manual pages"
-	@echo "  texinfo    to make Texinfo files"
-	@echo "  info       to make Texinfo files and run them through makeinfo"
-	@echo "  gettext    to make PO message catalogs"
-	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
 	-rm -rf tmp
@@ -70,108 +50,13 @@ html: pre-build
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml: pre-build
-	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml/$(LANG)
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
-
 singlehtml: pre-build
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml/$(LANG)
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
-
-pickle: pre-build
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle/$(LANG)
-	@echo
-	@echo "Build finished; now you can process the pickle files."
-
-json: pre-build
-	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json/$(LANG)
-	@echo
-	@echo "Build finished; now you can process the JSON files."
-
-htmlhelp: pre-build
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp/$(LANG)
-	@echo
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in $(BUILDDIR)/htmlhelp."
-
-qthelp: pre-build
-	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp/$(LANG)
-	@echo
-	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
-	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/Tuleap.qhcp"
-	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Tuleap.qhc"
-
-devhelp: pre-build
-	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp/$(LANG)
-	@echo
-	@echo "Build finished."
-	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/Tuleap"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Tuleap"
-	@echo "# devhelp"
-
-epub: pre-build
-	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub/$(LANG)
-	@echo
-	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
-
-latex: pre-build
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex/$(LANG)
-	@echo
-	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
-	@echo "Run \`make' in that directory to run these through (pdf)latex" \
-	      "(use \`make latexpdf' here to do that automatically)."
-
-latexpdf: pre-build
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex/$(LANG)
-	@echo "Running LaTeX files through pdflatex..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
-
-text: pre-build
-	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text/$(LANG)
-	@echo
-	@echo "Build finished. The text files are in $(BUILDDIR)/text."
-
-man: pre-build
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man/$(LANG)
-	@echo
-	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
-
-texinfo: pre-build
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo/$(LANG)
-	@echo
-	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
-	@echo "Run \`make' in that directory to run these through makeinfo" \
-	      "(use \`make info' here to do that automatically)."
-
-info: pre-build
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo/$(LANG)
-	@echo "Running Texinfo files through makeinfo..."
-	make -C $(BUILDDIR)/texinfo info
-	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
-
-gettext: pre-build
-	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale/$(LANG)
-	@echo
-	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
-
-changes: pre-build
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes/$(LANG)
-	@echo
-	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck: pre-build
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck/$(LANG)
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
-
-doctest: pre-build
-	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest/$(LANG)
-	@echo "Testing of doctests in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/doctest/output.txt."

--- a/README.md
+++ b/README.md
@@ -2,36 +2,24 @@ Tuleap Documentation
 ====================
 
 This is a proposal to use Sphinx (instead of docbook) in order to generate the 
-documentation for [Tuleap](http://tuleap.com/).
+documentation for [Tuleap](https://tuleap.org/).
 
-This is a work in progress. Please refer to the official documentation until this 
-becomes stable.
-
-Build the documentations
+Set-up your environment
 -----------------------
 
-    sudo apt-get install python-pip
-    sudo pip install -q Sphinx
-    cd /path/to/tuleap-documentation
+    virtualenv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    deactivate
+
+Build the documentation
+-----------------------
+
+    source venv/bin/activate
     make html
+    deactivate
 
-The documentation is generated in `_build/html/`
-
-Convert docbook files to reStructuredText
------------------------------------------
-
-First install latest version of pandoc:
-
-    sudo apt-get install haskell-platform
-    cabal update
-    cabal install pandoc
-
-Then convert the file from legacy documentation:
-
-    cd src/documentation/user_guide/en_US/
-    $HOME/.cabal/bin/pandoc -f docbook -s -w rst --toc ProjectAdministration.xml -o project-admin.rst 
-
-Move the file if `tuleap-documentation/languages/en/user-guide/` and modify the `tuleap-documentation/languages/en/index.rst` accordingly.
+The documentation is generated in `tuleap-documentation-fr/_build/html/fr/` You can check the modifications by opening `index.html` with your web browser. You need to build the documentation in order to see your modifications.
 
 License
 -------

--- a/languages/fr/conf.py
+++ b/languages/fr/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.pngmath']
+extensions = ['sphinx.ext.imgmath', 'sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -91,7 +91,7 @@ pygments_style = 'tango'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==2.2.0
+sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
Python 2 is EOLed at the beginning of next year but the Tuleap
build process still use it.

Added a basic CI check to make sure the documentation can be built.