### PR TITLE
Use the same nixpkgs pin than Tuleap main repo

### DIFF
--- a/build-support/pinned-nixpkgs.nix
+++ b/build-support/pinned-nixpkgs.nix
@@ -2,7 +2,7 @@
 
 let
   pinnedNixpkgs = import (fetchTarball { 
-    url = "https://github.com/NixOS/nixpkgs/archive/747927516efcb5e31ba03b7ff32f61f6d47e7d87.tar.gz";
-    sha256 = "1s4xabv59r99z8vd74w3r84kkxwqggqir3b0nh3ma04mni0m40gf";
+    url = "https://github.com/NixOS/nixpkgs/archive/af8cd5ded7735ca1df1a1174864daab75feeb64a.tar.gz";
+    sha256 = "0a81s3n25l2rk86gp2yxpnxv8a33cknml8z2snfzcsjp0g1a0xr3";
   } ) {};
 in pinnedNixpkgs


### PR DESCRIPTION
Part of request #33604: Update dev/build environment [W30 2023]