### PR TITLE
chore: Update nixpkgs pin

### DIFF
--- a/build-support/pinned-nixpkgs.nix
+++ b/build-support/pinned-nixpkgs.nix
@@ -2,8 +2,8 @@
 
 let
   pinnedNixpkgs = import (fetchTarball { 
-    url = "https://github.com/NixOS/nixpkgs/archive/f945939fd679284d736112d3d5410eb867f3b31c.tar.gz";
-    sha256 = "06da1wf4w752spsm16kkckfhxx5m09lwcs8931gwh76yvclq7257";
+    url = "https://github.com/NixOS/nixpkgs/archive/1e1dc66fe68972a76679644a5577828b6a7e8be4.tar.gz";
+    sha256 = "1nmra8aiiazi0w19x4cbb3qzy3l6ff9yaki3pkibhwh2grm88132";
   } ) {};
   poetry2nixsrc = builtins.fetchTarball {
     url = "https://github.com/nix-community/poetry2nix/archive/refs/tags/2024.2.2230616.tar.gz";


### PR DESCRIPTION
Use the same pin than for Tuleap main repo.

Part of request #37907 Update dev/build environment [W17 2024]