### PR TITLE
chore: Bump cachix/install-nix-action from v28 to v31

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # V28
+      - uses: cachix/install-nix-action@91a071959513ca103b54280ac0bef5b825791d4d # v31
       - name: Build
         run: nix-shell --pure --run 'make SPHINXOPTS='-W' html'


### PR DESCRIPTION
https://github.com/cachix/install-nix-action/releases/tag/v31
https://github.com/cachix/install-nix-action/releases/tag/v30
https://github.com/cachix/install-nix-action/releases/tag/v29